### PR TITLE
Missing simplejson import.

### DIFF
--- a/plugin.program.utorrent/addon.xml
+++ b/plugin.program.utorrent/addon.xml
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.program.utorrent"
        name="uTorrent"
-       version="1.1.3"
+       version="1.1.4"
        provider-name="Taxigps">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
+        <import addon="script.module.simplejson" version="3.3.0"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>executable</provides>


### PR DESCRIPTION
Without this import, this add-on will not run on Android versions of Kodi/XBMC.