### PR TITLE
Typo in xml header.

### DIFF
--- a/plugin.program.utorrent/resources/settings.xml
+++ b/plugin.program.utorrent/resources/settings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <settings>
 	<setting id="ip" type="text" label="30100" default="192.168.1.1" />
 	<setting id="port" type="text" label="30101" default="8080" />


### PR DESCRIPTION
XML header has a typo, encoding is set to "utf8" when it should be "UTF-8", causing an encoding error in Kodi/XBMC during install.