### PR TITLE
Support https, custom path and authentication using MD5 Digest Auth

### DIFF
--- a/plugin.program.utorrent/default.py
+++ b/plugin.program.utorrent/default.py
@@ -20,7 +20,10 @@ UT_PORT = __addon__.getSetting('port')
 UT_USER = __addon__.getSetting('usr')
 UT_PASSWORD = __addon__.getSetting('pwd')
 UT_TDIR = xbmc.translatePath( __addon__.getSetting('tdir') )
-baseurl = 'http://'+UT_ADDRESS+':'+UT_PORT+'/gui/?token='
+UT_HTTPS = __addon__.getSetting('use_https')
+UT_PATH = __addon__.getSetting('path')
+PROTO = 'https://' if UT_HTTPS else 'http://'
+baseurl = PROTO+UT_ADDRESS+':'+UT_PORT+UT_PATH+'?token='
 
 from utilities import *
 
@@ -28,12 +31,14 @@ params = {
     'address': UT_ADDRESS,
     'port': UT_PORT,
     'user': UT_USER,
-    'password': UT_PASSWORD
+    'password': UT_PASSWORD,
+    'path': UT_PATH,
+    'https': UT_HTTPS
 }
 myClient = Client(**params)
 
 def getToken():
-    tokenUrl = 'http://'+UT_ADDRESS+':'+UT_PORT+'/gui/token.html'
+    tokenUrl = PROTO+UT_ADDRESS+':'+UT_PORT+UT_PATH+'token.html'
 
     try:
         data = myClient.HttpCmd(tokenUrl)
@@ -148,9 +153,9 @@ def performAction(selection,sid):
     if sel == 7:
         files = getFiles(selection)
         if len(files) > 1: 
-             xbmc.Player().play('http://'+UT_USER+':'+UT_PASSWORD+'@'+UT_ADDRESS+':'+UT_PORT+'/proxy?sid='+sid+'&file='+str(dialog.select(__language__(32202),files)))
+             xbmc.Player().play(PROTO+UT_USER+':'+UT_PASSWORD+'@'+UT_ADDRESS+':'+UT_PORT+'/proxy?sid='+sid+'&file='+str(dialog.select(__language__(32202),files)))
         else:
-             xbmc.Player().play('http://'+UT_USER+':'+UT_PASSWORD+'@'+UT_ADDRESS+':'+UT_PORT+'/proxy?sid='+sid+'&file=0')
+             xbmc.Player().play(PROTO+UT_USER+':'+UT_PASSWORD+'@'+UT_ADDRESS+':'+UT_PORT+'/proxy?sid='+sid+'&file=0')
     xbmc.executebuiltin('Container.Refresh')
 
 def pauseAll():

--- a/plugin.program.utorrent/default.py
+++ b/plugin.program.utorrent/default.py
@@ -21,7 +21,9 @@ UT_USER = __addon__.getSetting('usr')
 UT_PASSWORD = __addon__.getSetting('pwd')
 UT_TDIR = xbmc.translatePath( __addon__.getSetting('tdir') )
 UT_HTTPS = __addon__.getSetting('use_https')
-UT_PATH = __addon__.getSetting('path')
+UT_PATH = '/' + __addon__.getSetting('path').strip('/') + '/'
+if UT_PATH != __addon__.getSetting('path'):
+    __addon__.setSetting('path', UT_PATH)
 PROTO = 'https://' if UT_HTTPS else 'http://'
 baseurl = PROTO+UT_ADDRESS+':'+UT_PORT+UT_PATH+'?token='
 

--- a/plugin.program.utorrent/resources/language/English/strings.xml
+++ b/plugin.program.utorrent/resources/language/English/strings.xml
@@ -11,7 +11,9 @@
 	<string id="30008">¡Þm</string>
 	<!-- Settings labels -->
 	<string id="30100">IP Address:</string>
+	<string id="30105">Use HTTPS:</string>
 	<string id="30101">Port:</string>
+	<string id="30106">Path:</string>
 	<string id="30102">User:</string>
 	<string id="30103">Password:</string>
 	<string id="30104">Torrent Path:</string>

--- a/plugin.program.utorrent/resources/lib/utilities.py
+++ b/plugin.program.utorrent/resources/lib/utilities.py
@@ -51,9 +51,10 @@ def MultiPart(fields,files,ftype) :
     return content_type, post
 
 class Client(object):
-    def __init__(self, address='localhost', port='8080', user=None, password=None):
-        base_url = 'http://' + address + ':' + port
-        self.url = base_url + '/gui/'
+    def __init__(self, address='localhost', port='8080', user=None, password=None, path='/gui/', https=False):
+        PROTO = 'https://' if https else 'http://'
+        base_url = PROTO + address + ':' + port
+        self.url = base_url + path
         if user:
             password_manager = urllib2.HTTPPasswordMgrWithDefaultRealm()
             password_manager.add_password(realm=None, uri=self.url, user=user, passwd=password)
@@ -62,6 +63,7 @@ class Client(object):
             opener = urllib2.build_opener(
                 urllib2.HTTPCookieProcessor(self.MyCookies)
                 , urllib2.HTTPBasicAuthHandler(password_manager)
+                , urllib2.HTTPDigestAuthHandler(password_manager)
                 )
             opener.addheaders = [('User-Agent', 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) chromeframe/4.0')]
             urllib2.install_opener(opener)

--- a/plugin.program.utorrent/resources/settings.xml
+++ b/plugin.program.utorrent/resources/settings.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <settings>
 	<setting id="ip" type="text" label="30100" default="192.168.1.1" />
+	<setting id="use_https" type="bool" label="30105" default="false" />
 	<setting id="port" type="text" label="30101" default="8080" />
+	<setting id="path" type="text" label="30106" default="/gui/" />
 	<setting id="usr" type="text" label="30102" default="admin" />
 	<setting id="pwd" type="text" label="30103" default="" option="hidden" />
 	<setting id="tdir" type="folder" source="files" label="30104" default="special://profile/torrents/" />


### PR DESCRIPTION
Problem:
My uTorrrent instance is accessable over https only and instead of path `/gui/`, it's `/torrent/`. Also, instead of basic auth, it's digest auth.

Solution:
- Added config options to use HTTPS instead of HTTP
- use custom path instead of default `/gui/`
- also now support Digest auth type

Tested with my own (https, /torrent/, digest) setup.
Not tested default (http, /gui/, basic) setup.

